### PR TITLE
Support Django up to 1.11, fix DeprecationWarnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,38 +2,43 @@ language: python
 sudo: false
 matrix:
   include:
-    - python: 3.5
-      env:
-      - TOX_ENV=py35-18
-    - python: 3.5
-      env:
-      - TOX_ENV=py35-18-postgres
-    - python: 3.5
-      env:
-      - TOX_ENV=py35-19
-env:
-  - TOX_ENV=py26-15
-  - TOX_ENV=py26-16
-  - TOX_ENV=py27-15
-  - TOX_ENV=py27-16
-  - TOX_ENV=py27-17
-  - TOX_ENV=py27-18
-  - TOX_ENV=py27-18-postgres
-  - TOX_ENV=py27-18-mysql
-  - TOX_ENV=py27-19
-  - TOX_ENV=pypy-15
-  - TOX_ENV=pypy-16
-  - TOX_ENV=pypy-17
-  - TOX_ENV=pypy-18
-  - TOX_ENV=pypy-18-mysql
-  - TOX_ENV=pypy-19
-  - TOX_ENV=py33-16
-  - TOX_ENV=py33-17
-  - TOX_ENV=py33-18
-  - TOX_ENV=py34-16
-  - TOX_ENV=py34-17
-  - TOX_ENV=py34-18
-  - TOX_ENV=py34-19
+    - { python: 2.6, env: TOXENV=py26-15 }
+    - { python: 2.6, env: TOXENV=py26-16 }
+    - { python: 2.7, env: TOXENV=py27-15 }
+    - { python: 2.7, env: TOXENV=py27-16 }
+    - { python: 2.7, env: TOXENV=py27-17 }
+    - { python: 2.7, env: TOXENV=py27-18 }
+    - { python: 2.7, env: TOXENV=py27-18-postgres }
+    - { python: 2.7, env: TOXENV=py27-18-mysql }
+    - { python: 2.7, env: TOXENV=py27-19 }
+    - { python: 2.7, env: TOXENV=py27-110 }
+    - { python: 2.7, env: TOXENV=py27-111 }
+    - { python: pypy, env: TOXENV=pypy-15 }
+    - { python: pypy, env: TOXENV=pypy-16 }
+    - { python: pypy, env: TOXENV=pypy-17 }
+    - { python: pypy, env: TOXENV=pypy-18 }
+    - { python: pypy, env: TOXENV=pypy-18-mysql }
+    - { python: pypy, env: TOXENV=pypy-19 }
+    - { python: pypy, env: TOXENV=pypy-110 }
+    - { python: pypy, env: TOXENV=pypy-111 }
+    - { python: 3.3, env: TOXENV=py33-16 }
+    - { python: 3.3, env: TOXENV=py33-17 }
+    - { python: 3.3, env: TOXENV=py33-18 }
+    - { python: 3.4, env: TOXENV=py34-16 }
+    - { python: 3.4, env: TOXENV=py34-17 }
+    - { python: 3.4, env: TOXENV=py34-18 }
+    - { python: 3.4, env: TOXENV=py34-19 }
+    - { python: 3.4, env: TOXENV=py34-110 }
+    - { python: 3.4, env: TOXENV=py34-111 }
+    - { python: 3.5, env: TOXENV=py35-18 }
+    - { python: 3.5, env: TOXENV=py35-18-postgres }
+    - { python: 3.5, env: TOXENV=py35-19 }
+    - { python: 3.5, env: TOXENV=py35-110 }
+    - { python: 3.5, env: TOXENV=py35-111 }
+    - { python: 3.6, env: TOXENV=py36-111 }
+    - { python: 3.6, env: TOXENV=py36-master-postgres }
+  allow_failures:
+    - env: TOXENV=py36-master-postgres
 before_install:
   - export PIP_USE_MIRRORS=true
   - export DJANGO_SETTINGS_MODULE=test_settings
@@ -47,7 +52,7 @@ before_install:
 install:
   - pip install tox
 script:
-  - tox -e $TOX_ENV -v
+  - tox -v
 deploy:
   provider: pypi
   user: gremu

--- a/example/testapp/models.py
+++ b/example/testapp/models.py
@@ -1,22 +1,28 @@
 # -*- coding: utf-8 -*-
 from django.db import models
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
+from django.utils.encoding import python_2_unicode_compatible
 from sortedm2m.fields import SortedManyToManyField
 
 
+@python_2_unicode_compatible
 class Car(models.Model):
     plate = models.CharField(max_length=50)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.plate
 
 
+@python_2_unicode_compatible
 class ParkingArea(models.Model):
     name = models.CharField(max_length=50)
     cars = SortedManyToManyField(Car)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
-    @models.permalink
     def get_absolute_url(self):
-        return 'parkingarea', (self.pk,), {}
+        return reverse('parkingarea', (self.pk,))

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import include, patterns, url
+import django
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.conf import settings
 from django.http import HttpResponse
+import django.views.static
 
+import example.testapp.views
 
 admin.autodiscover()
 
@@ -16,9 +19,13 @@ handler404 = 'example.urls.handle404'
 handler500 = 'example.urls.handle500'
 
 
-urlpatterns = patterns('',
-    url(r'^media/(.*)$', 'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
-    url(r'^admin/', include(admin.site.urls), name="admin"),
-    url(r'^parkingarea/(?P<pk>\d+)/$', 'example.testapp.views.parkingarea_update', name='parkingarea'),
+if django.VERSION < (1, 9):
+    urlpatterns = [url(r'^admin/', include(admin.site.urls), name="admin")]
+else:
+    urlpatterns = [url(r'^admin/', admin.site.urls, name="admin")]
+
+urlpatterns += [
+    url(r'^media/(.*)$', django.views.static.serve, {'document_root': settings.MEDIA_ROOT}),
+    url(r'^parkingarea/(?P<pk>\d+)/$', example.testapp.views.parkingarea_update, name='parkingarea'),
     url(r'^', include('django.contrib.staticfiles.urls')),
-)
+]

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,0 @@
-South==0.8.4
-argparse
-mock==1.0.1

--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import os, sys
+import os, sys, warnings
 
 
 parent = os.path.dirname(os.path.abspath(__file__))
@@ -32,6 +32,20 @@ else:
 
 
 def runtests(*args):
+    if django.VERSION > (1, 8):
+        warnings.simplefilter("error", Warning)
+        warnings.filterwarnings("ignore", module="distutils")
+        try:
+            warnings.filterwarnings("ignore", category=ResourceWarning)
+        except NameError:
+            pass
+        warnings.filterwarnings("ignore", "invalid escape sequence", DeprecationWarning)
+        # Ignore a python 3.6 DeprecationWarning in ModelBase.__new__ that isn't
+        # fixed in Django 1.x
+        if sys.version_info > (3, 6) and django.VERSION < (2,):
+            warnings.filterwarnings(
+                "ignore", "__class__ not set defining", DeprecationWarning)
+
     test_apps = list(args or default_test_apps)
     execute_from_command_line([sys.argv[0], 'test', '--verbosity=1'] + test_apps)
 

--- a/sortedm2m/compat.py
+++ b/sortedm2m/compat.py
@@ -11,12 +11,21 @@ if apps is not None:
 else:
     from django.db.models import get_model
 
+from django.db import models
 
 try:
     from django.db.models.fields.related_descriptors import create_forward_many_to_many_manager
 except ImportError:
     # Django <= 1.8 support.
     from django.db.models.fields.related import create_many_related_manager as create_forward_many_to_many_manager
+
+try:
+    from django.db.models.fields.related import lazy_related_operation
+except ImportError:
+    lazy_related_operation = None
+    from django.db.models.fields.related import add_lazy_relation as _add_lazy_relation
+else:
+    _add_lazy_relation = None
 
 
 def get_model_name(model):
@@ -32,9 +41,11 @@ def get_foreignkey_field_kwargs(field):
     if django.VERSION < (1, 6):
         return {}
     else:
-        return dict(
-            db_tablespace=field.db_tablespace,
-            db_constraint=field.rel.db_constraint)
+        return {
+            'db_tablespace': field.db_tablespace,
+            'db_constraint': get_rel(field).db_constraint,
+            'on_delete': models.CASCADE,
+        }
 
 
 def get_field(model, field_name):
@@ -56,3 +67,28 @@ def allow_migrate_model(self, connection_alias, model):
         return self.allowed_to_migrate(connection_alias, model)
     else:
         return self.allow_migrate_model(connection_alias, model)
+
+
+def get_rel(f):
+    if django.VERSION > (1, 9):
+        return f.remote_field
+    else:
+        return f.rel
+
+def get_rel_to(f):
+    rel = get_rel(f)
+    if django.VERSION > (1, 9):
+        return rel.model
+    else:
+        return rel.to
+
+
+def add_lazy_relation(cls, field, relation, operation):
+    if _add_lazy_relation is not None:
+        return _add_lazy_relation(cls, field, relation, operation)
+
+    # Rearrange args for new Apps.lazy_model_operation
+    def function(local, related, field):
+        return operation(field, related, local)
+
+    lazy_related_operation(function, cls, relation, field=field)

--- a/sortedm2m/forms.py
+++ b/sortedm2m/forms.py
@@ -31,14 +31,14 @@ class SortedCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
         )}
 
     def build_attrs(self, attrs=None, **kwargs):
-        attrs = super(SortedCheckboxSelectMultiple, self).\
-            build_attrs(attrs, **kwargs)
+        attrs = dict(attrs or {}, **kwargs)
+        attrs = super(SortedCheckboxSelectMultiple, self).build_attrs(attrs)
         classes = attrs.setdefault('class', '').split()
         classes.append('sortedm2m')
         attrs['class'] = ' '.join(classes)
         return attrs
 
-    def render(self, name, value, attrs=None, choices=()):
+    def render(self, name, value, attrs=None, choices=(), renderer=None):
         if value is None: value = []
         has_id = attrs and 'id' in attrs
         final_attrs = self.build_attrs(attrs, name=name)

--- a/sortedm2m/operations.py
+++ b/sortedm2m/operations.py
@@ -2,9 +2,8 @@ from django.db import models
 from django.db.migrations.operations import AlterField
 
 from sortedm2m.fields import SORT_VALUE_FIELD_NAME
-from .compat import get_field
-from .compat import get_apps_from_state
-from .compat import allow_migrate_model
+from .compat import (
+    get_field, get_apps_from_state, allow_migrate_model, get_rel)
 
 
 class AlterSortedManyToManyField(AlterField):
@@ -21,8 +20,8 @@ class AlterSortedManyToManyField(AlterField):
             from_model = from_apps.get_model(app_label, self.model_name)
             from_field = get_field(from_model, self.name)
 
-            to_m2m_model = to_field.rel.through
-            from_m2m_model = from_field.rel.through
+            to_m2m_model = get_rel(to_field).through
+            from_m2m_model = get_rel(from_field).through
 
             # M2M -> SortedM2M
             if getattr(to_field, 'sorted', False):
@@ -47,8 +46,8 @@ class AlterSortedManyToManyField(AlterField):
 
         if allow_migrate_model(self, schema_editor.connection.alias, to_model):
             to_field = get_field(to_model, self.name)
-            from_m2m_model = from_field.rel.through
-            to_m2m_model = to_field.rel.through
+            from_m2m_model = get_rel(from_field).through
+            to_m2m_model = get_rel(to_field).through
 
             # The `to_state` is the OLDER state.
 

--- a/sortedm2m_tests/migrations_tests/models.py
+++ b/sortedm2m_tests/migrations_tests/models.py
@@ -1,8 +1,10 @@
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from sortedm2m.fields import SortedManyToManyField
 
 
+@python_2_unicode_compatible
 class Photo(models.Model):
     name = models.CharField(max_length=50)
 
@@ -10,10 +12,11 @@ class Photo(models.Model):
         verbose_name = _('Photo')
         verbose_name_plural = _('Photos')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class Gallery(models.Model):
     name = models.CharField(max_length=50)
     photos = SortedManyToManyField(Photo)
@@ -23,5 +26,5 @@ class Gallery(models.Model):
         verbose_name = _('Photo')
         verbose_name_plural = _('Photos')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name

--- a/sortedm2m_tests/models.py
+++ b/sortedm2m_tests/models.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.encoding import force_unicode as force_text
 from sortedm2m.fields import SortedManyToManyField
 
 
@@ -7,10 +12,11 @@ class Shelf(models.Model):
     books = SortedManyToManyField('Book', related_name='shelves')
 
 
+@python_2_unicode_compatible
 class Book(models.Model):
     name = models.CharField(max_length=50)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -30,8 +36,9 @@ class MessyStore(models.Model):
         related_name='messy_stores')
 
 
+@python_2_unicode_compatible
 class SelfReference(models.Model):
     me = SortedManyToManyField('self', related_name='hide+')
 
-    def __unicode__(self):
-        return unicode(self.pk)
+    def __str__(self):
+        return force_text(self.pk)

--- a/sortedm2m_tests/test_field.py
+++ b/sortedm2m_tests/test_field.py
@@ -1,17 +1,25 @@
 # -*- coding: utf-8 -*-
+import django
 from django.db import connection
 from django.db.models.fields import FieldDoesNotExist
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import six
 
-from sortedm2m.compat import get_field
+from sortedm2m.compat import get_field, get_rel
 
 from .models import (
     Book, Shelf, DoItYourselfShelf, Store, MessyStore, SelfReference)
 
 
 str_ = six.text_type
+
+
+def m2m_set(instance, field_name, objs):
+    if django.VERSION > (1, 9):
+        getattr(instance, field_name).set(objs)
+    else:
+        setattr(instance, field_name, objs)
 
 
 class TestSortedManyToManyField(TestCase):
@@ -80,24 +88,24 @@ class TestSortedManyToManyField(TestCase):
         self.assertEqual(list(shelf.books.all()), [])
 
         books = self.books[5:2:-1]
-        shelf.books = books
+        m2m_set(shelf, "books", books)
         self.assertEqual(list(shelf.books.all()), books)
 
         books.reverse()
-        shelf.books = books
+        m2m_set(shelf, "books", books)
         self.assertEqual(list(shelf.books.all()), books)
 
         shelf.books.add(self.books[8])
         self.assertEqual(list(shelf.books.all()), books + [self.books[8]])
 
-        shelf.books = []
+        m2m_set(shelf, "books", [])
         self.assertEqual(list(shelf.books.all()), [])
 
-        shelf.books = [self.books[9]]
+        m2m_set(shelf, "books", [self.books[9]])
         self.assertEqual(list(shelf.books.all()), [
             self.books[9]])
 
-        shelf.books = []
+        m2m_set(shelf, "books", [])
         self.assertEqual(list(shelf.books.all()), [])
 
     def test_set_items_by_pk(self):
@@ -105,20 +113,20 @@ class TestSortedManyToManyField(TestCase):
         self.assertEqual(list(shelf.books.all()), [])
 
         books = self.books[5:2:-1]
-        shelf.books = [b.pk for b in books]
+        m2m_set(shelf, "books", [b.pk for b in books])
         self.assertEqual(list(shelf.books.all()), books)
 
-        shelf.books = [self.books[5].pk, self.books[2]]
+        m2m_set(shelf, "books", [self.books[5].pk, self.books[2]])
         self.assertEqual(list(shelf.books.all()), [
             self.books[5],
             self.books[2]])
 
-        shelf.books = [str_(self.books[8].pk)]
+        m2m_set(shelf, "books", [str_(self.books[8].pk)])
         self.assertEqual(list(shelf.books.all()), [self.books[8]])
 
     def test_remove_items(self):
         shelf = self.model.objects.create()
-        shelf.books = self.books[2:5]
+        m2m_set(shelf, "books", self.books[2:5])
         self.assertEqual(list(shelf.books.all()), [
             self.books[2],
             self.books[3],
@@ -134,7 +142,7 @@ class TestSortedManyToManyField(TestCase):
 
     def test_remove_items_by_pk(self):
         shelf = self.model.objects.create()
-        shelf.books = self.books[2:5]
+        m2m_set(shelf, "books", self.books[2:5])
         self.assertEqual(list(shelf.books.all()), [
             self.books[2],
             self.books[3],
@@ -176,7 +184,7 @@ class TestSortedManyToManyField(TestCase):
     def test_prefetch_related_sorting(self):
         shelf = self.model.objects.create()
         books = [self.books[0], self.books[2], self.books[1]]
-        shelf.books = books
+        m2m_set(shelf, "books", books)
 
         shelf = self.model.objects.filter(pk=shelf.pk).prefetch_related('books')[0]
         def get_ids(queryset):
@@ -205,7 +213,7 @@ class TestStringReference(TestSortedManyToManyField):
 
         self.assertEqual(len(self.model._meta.many_to_many), 1)
         sortedm2m = self.model._meta.many_to_many[0]
-        intermediate_model = sortedm2m.rel.through
+        intermediate_model = get_rel(sortedm2m).through
 
         # make sure that standard sort field is not used
         self.assertRaises(

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -1,5 +1,8 @@
 # Django settings for testsite project.
 import os
+import django
+
+
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
 DEBUG = True
@@ -48,12 +51,23 @@ STATIC_URL = '/static/'
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'define in local settings file'
 
-MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-)
+if django.VERSION >= (1, 10):
+    MIDDLEWARE = [
+        'django.middleware.security.SecurityMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    ]
+else:
+    MIDDLEWARE_CLASSES = (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    )
 
 ROOT_URLCONF = 'example.urls'
 

--- a/test_south_support/models.py
+++ b/test_south_support/models.py
@@ -1,26 +1,30 @@
 # -*- coding: utf-8 -*-
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from sortedm2m.fields import SortedManyToManyField
 
 
+@python_2_unicode_compatible
 class Photo(models.Model):
     name = models.CharField(max_length=30)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class Gallery(models.Model):
     name = models.CharField(max_length=30)
     photos = SortedManyToManyField(Photo)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class UnsortedGallery(models.Model):
     name = models.CharField(max_length=30)
     photos = SortedManyToManyField(Photo, sorted=False)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name

--- a/test_south_support/south_support_custom_sort_field_name/models.py
+++ b/test_south_support/south_support_custom_sort_field_name/models.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from ..models import Photo
 from sortedm2m.fields import SortedManyToManyField
 
 
 # this model is not considered in the existing migrations. South will try to
 # create this model.
+@python_2_unicode_compatible
 class FeaturedPhotos(models.Model):
     name = models.CharField(max_length=30)
     photos = SortedManyToManyField(Photo,
         sort_value_field_name='featured_nr')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name

--- a/test_south_support/south_support_new_field/models.py
+++ b/test_south_support/south_support_new_field/models.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from ..models import Photo
 from sortedm2m.fields import SortedManyToManyField
 
 
 # this model is already created in the schemamigrations but the ``photos``
 # field is missing from the DB. So south will try to create it.
+@python_2_unicode_compatible
 class PhotoStream(models.Model):
     name = models.CharField(max_length=30)
     photos = SortedManyToManyField(Photo, sorted=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name

--- a/test_south_support/south_support_new_model/models.py
+++ b/test_south_support/south_support_new_model/models.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from ..models import Photo
 from sortedm2m.fields import SortedManyToManyField
 
 
 # this model is not considered in the existing migrations. South will try to
 # create this model.
+@python_2_unicode_compatible
 class CompleteNewPhotoStream(models.Model):
     name = models.CharField(max_length=30)
     new_photos = SortedManyToManyField(Photo, sorted=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,11 @@
 minversion = 1.8
 envlist =
     py26-{15,16},
-    py27-{15,16,17,18,19},
+    {py27,pypy}-{15,16,17,18,19,110,111},
     py33-{16,17,18},
-    py34-{16,17,18,19},
-    py35-{18,19},
-    pypy-{15,16,17,18,19}
+    py34-{16,17,18,19,110,111},
+    py35-{18,19,110,111},
+    py36-{111,master}
 
 [testenv]
 commands = python runtests.py
@@ -15,12 +15,16 @@ deps =
     15: Django >= 1.5, < 1.6
     16: Django >= 1.6, < 1.7
     17: Django >= 1.7, < 1.8
+    14,15,16,17: South==0.8.4
     18: Django >= 1.8, < 1.9
     19: Django >= 1.9, < 1.10
+    110: Django>=1.10,<1.10.99
+    111: Django>=1.11a1,<1.11.99
     master: https://github.com/django/django/tarball/master#egg=Django
     postgres: psycopg2
     mysql: MySQL-python
-    -r{toxinidir}/requirements/tests.txt
+    py26: argparse
+    mock==1.0.1
 setenv =
     DJANGO_SETTINGS_MODULE = test_project.settings
     postgres: DJANGO_SETTINGS_MODULE = test_project.postgres_settings


### PR DESCRIPTION
Also set warnings to raise as errors in unit tests to prevent
regressions that re-introduce the warnings.